### PR TITLE
add configurable PDO options setting, fix warning in query() on INSERT/UPDATE/DELETE

### DIFF
--- a/src/users/classes/DB.php
+++ b/src/users/classes/DB.php
@@ -22,13 +22,15 @@ class DB {
 	private $_pdo, $_query, $_error = false, $_results, $_resultsArray, $_count = 0, $_lastId, $_queryCount=0;
 
 	private function __construct(){
+		if (!$opts = Config::get('mysql/options'))
+			$opts = array(PDO::MYSQL_ATTR_INIT_COMMAND => "SET SESSION sql_mode = ''");
 		try{
 			$this->_pdo = new PDO('mysql:host=' .
-				Config::get('mysql/host') .';dbname='. 
-				Config::get('mysql/db'), 
-				Config::get('mysql/username'), 
+				Config::get('mysql/host') .';dbname='.
+				Config::get('mysql/db'),
+				Config::get('mysql/username'),
 				Config::get('mysql/password'),
-				array(PDO::MYSQL_ATTR_INIT_COMMAND => "SET SESSION sql_mode = ''"));
+				$opts);
 		} catch(PDOException $e){
 			die($e->getMessage());
 		}
@@ -54,8 +56,10 @@ class DB {
 			}
 
 			if ($this->_query->execute()) {
-				$this->_results = $this->_query->fetchALL(PDO::FETCH_OBJ);
-				$this->_resultsArray = json_decode(json_encode($this->_results),true);
+				if ($this->_query->columnCount() > 0) {
+					$this->_results = $this->_query->fetchALL(PDO::FETCH_OBJ);
+					$this->_resultsArray = json_decode(json_encode($this->_results),true);
+				}
 				$this->_count = $this->_query->rowCount();
 				$this->_lastId = $this->_pdo->lastInsertId();
 			} else{
@@ -119,7 +123,7 @@ class DB {
 		}
 
 		$sql = "INSERT INTO {$table} (`". implode('`,`', $keys)."`) VALUES ({$values})";
-		
+
 		if (!$this->query($sql, $fields)->error()) {
 			return true;
 		}
@@ -166,12 +170,12 @@ class DB {
 	public function lastId(){
 		return $this->_lastId;
 	}
-	
+
 	public function getQueryCount(){
 		return $this->_queryCount;
-	}	
+	}
 	public function getAttribute($attributeValue=null){
 		return $this->_pdo->getAttribute(constant($attributeValue));
 	}
-	
+
 }


### PR DESCRIPTION
(1) Allowed a Config::get('mysql/options') to set the PDO options on
    __construct()
(2) Fixed a warning whereby a fetch() was executed on DELETE/INSERT/UPDATE
    queries
