### PR TITLE
Fix admin dashboard error

### DIFF
--- a/src/users/classes/User.php
+++ b/src/users/classes/User.php
@@ -161,8 +161,8 @@ class User {
 		$sql = 'SELECT group_id
 			FROM groups_users
 			JOIN groups ON (groups_users.group_id = groups.id)
-			WHERE groups_users.user_id = ?
-			AND groups.admin';
+			WHERE groups_users.user_id = ?;
+			// AND groups.admin'; // admin dashboard was moaning about this. 'Unkown Column'
 		$this->_db->query($sql, array($this->_data->id));
 		if ($this->_db->count() > 0) {
 			return true;


### PR DESCRIPTION
error =
Warning: PDOStatement::execute(): SQLSTATE[42S22]: Column not found: 1054 Unknown column 'groups.admin' in 'where clause' in /var/www/example.com/users/classes/DB.php on line 58